### PR TITLE
Create a new bibtex tag for search during a new query

### DIFF
--- a/.#README.md
+++ b/.#README.md
@@ -1,1 +1,0 @@
-Hong@rmbp13.local.33506

--- a/.#README.md
+++ b/.#README.md
@@ -1,0 +1,1 @@
+Hong@rmbp13.local.33506

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# google-scholar-citations
+# Google Scholar Citations
 Want to know who/which journal has cited your work and compile a list?
 
 This program allows you to retrieve all the citations an author has garnered from other scholars via Google Scholar, to store them in a bib file, and optionally, to download the publicly available PDF files associated with those citations.
@@ -7,11 +7,17 @@ This program allows you to retrieve all the citations an author has garnered fro
 * Python 2.7.9+ or Python 3
   - [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-beautiful-soup)
   - [requests](http://requests.readthedocs.io/en/latest/user/install/#install)
+  - [bibtexparser](https://bibtexparser.readthedocs.io/en/v0.6.2/install.html)
 * Latex if you need to produce a final PDF report
 
+## Download
+To download, either clone/download the repository, or clone it via command line with:
+```bash
+$ git clone https://github.com/shiqiezi/google-scholar-citations
+```
 
 ## Basic Usage
-Basic command line input is needed. A very basic usage will be:
+Basic command line operation is needed. A very basic usage with defaults will be:
 
 ```bash
 $ python main.py https://scholar.google.com/citations?user=lqyGZpQAAAAJ
@@ -24,7 +30,7 @@ $ python main.py [-h] [--request-interval REQUEST_INTERVAL] [--should-download]
                google_scholar_uri
 ```
 
-### optional arguments:
+### optional arguments explained:
 ```bash
   --request-interval REQUEST_INTERVAL
                         # Interval (in seconds) between requests to google scholar
@@ -53,4 +59,4 @@ $ python main.py -h # show this help message and exit
 Crawl the web resposibly. We suggest that users set a large number for the --request-interval. Requesting too frequently may result in a block from Google.
 
 ## History
-*18-Sep-2016*: Enabled a number of commandline options, updated README
+*18-Sep-2016*: Enabled a number of command line options, updated README

--- a/main.py
+++ b/main.py
@@ -141,7 +141,7 @@ def save_citation(citation_record):
     bib_entry = "%% [%d]\n%s" % (citation_num, g_bib_entry)
     logging.info(bib_entry.strip())
     with open(opts.citation_name, "a+") as f:
-        f.write(g_bib_entry.encode('utf-8'))
+        f.write(bib_entry.encode('utf-8'))
     if opts.should_download:
         pdf_div = citation_record.find('div', {"class": "gs_ggs gs_fl"})
         if pdf_div:


### PR DESCRIPTION
@liuml07 @shiqiezi 

In this version, I added two things:
1. A google scholar citation id tag, that can possibly be parsed and used by us or the user, given this is a unique ID for that citation. 
2. Added the paper's citationID (e.g., "hong2014global") to the pdf file, the format is currently citation_num_citationID (1_hong2014global.pdf) to help users understand which paper it is.

To-do:
I have not figured out the best way to do the comparison of existing citations and new ones, say, I want to run the program 2 months from now and only write into the bib file the new citations.

My logic was to parse the bib file and make a list of the gscholar_id named "gscholar_ids", do a logical test whether the citation_id is in gscholar_ids, if not, parse and add.

The challenge here is that it might inadvertently mess with the citation_num, because new citations tend to be on top? Say, the new citation on top supposedly becomes [1], but it is skipped by the reconnection function (断点续传)。

Let me know what you guys think?
